### PR TITLE
Fix: 배포 시 415 에러 발생하여 @PostMapping의 consumes 파라미터 작성

### DIFF
--- a/src/main/java/com/djs/dongjibsabackend/controller/PostImageController.java
+++ b/src/main/java/com/djs/dongjibsabackend/controller/PostImageController.java
@@ -6,6 +6,7 @@ import com.djs.dongjibsabackend.service.PostImageService;
 import com.djs.dongjibsabackend.service.PostService;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,7 +24,8 @@ public class PostImageController {
     private final PostService postService;
     private final PostImageService postImageService;
 
-    @PostMapping(path = "/{postId}/uploadImage", consumes = {"multipart/form-data"}, headers = ("content-type=multipart/*"))
+    @PostMapping(path = "/{postId}/uploadImage",
+        consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE}, headers = ("content-type=multipart/*"))
     @ResponseBody
     public Response<String> uploadRecipeImage (
         @RequestParam("image") MultipartFile multipartFile,


### PR DESCRIPTION
- 에러 발생 상황
배포 서버 테스트 진행 중 지원되지 않는 미디어 타입이라는 415 에러 발생

- 해결방법
PostMapping 어노테이션의 consume 파라미터를 Json 값과 multipart 값으로 별도 지정하였음
