### PR TITLE
Refactor: 게시글 리스트 전체 조회 시 List로 반환

### DIFF
--- a/src/main/java/com/djs/dongjibsabackend/controller/PostController.java
+++ b/src/main/java/com/djs/dongjibsabackend/controller/PostController.java
@@ -70,11 +70,9 @@ public class PostController {
 
     // 게시글 리스트 조회
     @GetMapping("")
-    public Response<Page<PostDto>> getAllRecipeList(@PageableDefault(size = 20)
-                                                    @SortDefault (sort = "createdAt", direction = Direction.DESC)
-                                                    Pageable pageable) {
+    public Response<List<PostDto>> getAllRecipeList() {
 
-        Page<PostDto> postDtoList = postService.getRecipeList(pageable);
+        List<PostDto> postDtoList = postService.getRecipeList();
 
         return Response.success(postDtoList);
     }

--- a/src/main/java/com/djs/dongjibsabackend/repository/PostRepository.java
+++ b/src/main/java/com/djs/dongjibsabackend/repository/PostRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostRepository extends JpaRepository<PostEntity, Long> {
     // List<PostEntity> findAllByLocationId(Long locationId);
-    Page<PostEntity> findAll(Pageable pageable);
-
+    List<PostEntity> findAll();
     List<PostEntity> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/djs/dongjibsabackend/service/PostService.java
+++ b/src/main/java/com/djs/dongjibsabackend/service/PostService.java
@@ -162,16 +162,15 @@ public class PostService {
 //        return savedPostDto;
 //    }
 
-    // 조회
-    // List<RecipeIngredientEntity> recipeIngredients = recipeIngredientRepository.findAllIngredientsByRecipeId() -> 조회 로직에 사용할 것
-    public Page<PostDto> getRecipeList (Pageable pageable) {
+    /* 게시글 전체 조회*/
+    public List<PostDto> getRecipeList() {
 
-        Page<PostEntity> postEntityList = postRepository.findAll(pageable);
-        Page<PostDto> postDtoList = PostDto.toDtoPage(postEntityList);
+        List<PostEntity> postEntityList = postRepository.findAll();
+        List<PostDto> postDtoList = PostDto.toDtoList(postEntityList);
         return postDtoList;
     }
 
-    // 게시글 상세조회
+    /* 게시글 상세조회 */
     public PostDto getPostDetail(Long postId) {
         PostEntity post = postRepository.findById(postId)
                                         .orElseThrow(() -> new AppException(ErrorCode.POST_NOT_FOUND, "게시물이 존재하지 않습니다."));


### PR DESCRIPTION
- 프론트에서 게시글 전체 조회 기능 호출 시 Page 객체의 불필요한 데이터가 나오는 것으로 인해 파싱 이슈가 있었음
- 이를 해결하기 위해 List 객체로 전체 게시글을 한 번에 호출하는 로직으로 변경