### PR TITLE
게시글 작성 기능 리팩토링

### DIFF
--- a/src/main/java/com/djs/dongjibsabackend/domain/dto/ingredient/IngredientDto.java
+++ b/src/main/java/com/djs/dongjibsabackend/domain/dto/ingredient/IngredientDto.java
@@ -1,5 +1,6 @@
 package com.djs.dongjibsabackend.domain.dto.ingredient;
 
+import com.djs.dongjibsabackend.domain.entity.IngredientEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,4 +19,10 @@ public class IngredientDto {
         this.name = name;
     }
 
+    public static IngredientEntity toEntity(IngredientDto ingredientDto) {
+
+        return IngredientEntity.builder()
+                               .ingredientName(ingredientDto.getName())
+                               .build();
+    }
 }

--- a/src/main/java/com/djs/dongjibsabackend/domain/dto/post/RegisterPostRequest.java
+++ b/src/main/java/com/djs/dongjibsabackend/domain/dto/post/RegisterPostRequest.java
@@ -17,15 +17,15 @@ import org.springframework.web.multipart.MultipartFile;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RegisterPostRequest {
 
+    private Long memberId; // 유저 id값
+
     private String title; // 글 제목
-    private String userName; // 작성자 이름
-    private String recipeName; // 레시피 이름
+    private String content; // 내용
+    private String recipeName; // 레시피명
     private Integer expectingPrice; // 예상 가격
     private Integer pricePerOne; // 1인 당 예상 가격
     private Integer peopleCount; // 파티원 수
-    private String dong; // 위치 dto
     private List<PostIngredientRequest> ingredients; // 게시글 재료 목록
-    private String content; // 내용
     private MultipartFile image; // 레시피 사진
 
 }

--- a/src/main/java/com/djs/dongjibsabackend/domain/dto/post_ingredient/PostIngredientRequest.java
+++ b/src/main/java/com/djs/dongjibsabackend/domain/dto/post_ingredient/PostIngredientRequest.java
@@ -17,4 +17,4 @@ public class PostIngredientRequest {
     private double requiredQty;
     private double sharingAvailableQty;
 
-}가
+}

--- a/src/main/java/com/djs/dongjibsabackend/domain/dto/post_ingredient/PostIngredientRequest.java
+++ b/src/main/java/com/djs/dongjibsabackend/domain/dto/post_ingredient/PostIngredientRequest.java
@@ -9,9 +9,12 @@ import lombok.Setter;
 @Setter
 public class PostIngredientRequest {
 
+    /**
+     *  재료 이름, 구매 수량, 필요 수량, 판매 수량
+     */
     private String ingredientName;
     private double totalQty;
     private double requiredQty;
     private double sharingAvailableQty;
 
-}
+}가

--- a/src/main/java/com/djs/dongjibsabackend/domain/dto/recipe_calorie/RecipeCalorieDto.java
+++ b/src/main/java/com/djs/dongjibsabackend/domain/dto/recipe_calorie/RecipeCalorieDto.java
@@ -29,4 +29,11 @@ public class RecipeCalorieDto {
                                .calorie(recipeCalorie.getCalorie())
                                .build();
     }
+
+    public static RecipeCalorieEntity toEntity (RecipeCalorieDto dto) {
+        return RecipeCalorieEntity.builder()
+                                  .recipeName(dto.recipeName)
+                                  .calorie(dto.calorie)
+                                  .build();
+    }
 }

--- a/src/main/java/com/djs/dongjibsabackend/domain/entity/IngredientEntity.java
+++ b/src/main/java/com/djs/dongjibsabackend/domain/entity/IngredientEntity.java
@@ -6,11 +6,15 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @Table(name = "ingredient")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class IngredientEntity {
 
     @Id
@@ -19,4 +23,9 @@ public class IngredientEntity {
     private Long id;
     private String ingredientName;
 
+    @Builder
+    public IngredientEntity(Long id, String ingredientName) {
+        this.id = id;
+        this.ingredientName = ingredientName;
+    }
 }

--- a/src/main/java/com/djs/dongjibsabackend/domain/entity/PostEntity.java
+++ b/src/main/java/com/djs/dongjibsabackend/domain/entity/PostEntity.java
@@ -52,8 +52,8 @@ public class PostEntity extends BaseEntity {
     // 재료-수량 객체 리스트
     @OneToMany(mappedBy = "post", orphanRemoval = true, cascade = CascadeType.ALL)
     private List<PostIngredientEntity> recipeIngredients = new ArrayList<>();
-    private String imgUrl; // 레시피 이미지 Url
 
+    private String imgUrl; // 레시피 이미지 Url
 
     @Builder
     public PostEntity(Long id, String title, String content,
@@ -76,13 +76,19 @@ public class PostEntity extends BaseEntity {
         this.imgUrl = imgUrl;
     }
 
-    // --- 연관 관계 메서드 --- //
+    // ** Methods
+    /* 1. 재료 목록 업데이트 */
     public void updatePostIngredients(List<PostIngredientEntity> recipeIngredients) {
         this.recipeIngredients = recipeIngredients;
     }
 
-    // --- 이미지 url 업데이트 메서드 --- //
+    /* 2. S3 Url 업데이트 */
     public void updatePostImageUrl(String s3FileUrl) {
         this.imgUrl = s3FileUrl;
+    }
+
+    /* 3. 칼로리 업데이트 */
+    public void updateRecipeCalorie(RecipeCalorieEntity recipeCalorieEntity) {
+        this.recipeCalorie = recipeCalorieEntity;
     }
 }

--- a/src/main/java/com/djs/dongjibsabackend/domain/entity/RecipeCalorieEntity.java
+++ b/src/main/java/com/djs/dongjibsabackend/domain/entity/RecipeCalorieEntity.java
@@ -7,12 +7,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "recipe_calorie")
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RecipeCalorieEntity {
 
     @Id
@@ -22,4 +24,10 @@ public class RecipeCalorieEntity {
     private String recipeName;
     private double calorie;
 
+    @Builder
+    public RecipeCalorieEntity(Long id, String recipeName, double calorie) {
+        this.id = id;
+        this.recipeName = recipeName;
+        this.calorie = calorie;
+    }
 }

--- a/src/main/java/com/djs/dongjibsabackend/repository/RecipeCalorieRepository.java
+++ b/src/main/java/com/djs/dongjibsabackend/repository/RecipeCalorieRepository.java
@@ -1,10 +1,12 @@
 package com.djs.dongjibsabackend.repository;
 
 import com.djs.dongjibsabackend.domain.entity.RecipeCalorieEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecipeCalorieRepository extends JpaRepository<RecipeCalorieEntity, Long> {
 
-    RecipeCalorieEntity findByRecipeName(String recipeName);
+     Optional<RecipeCalorieEntity> findByRecipeName(String recipeName);
+//    RecipeCalorieEntity findByRecipeName(String recipeName);
 
 }


### PR DESCRIPTION
1. 레시피 입력
- 게시글 작성 시 레시피 명을 입력할 때, DB에 존재하지 않으면 저장되지 않았음
- 레시피 명을 검증하여 DB에 존재하면 해당 레시피의 칼로리를 게시글과 저장하고, 존재하지 않으면 칼로리를 0으로 하여 DB에 입력한 후 해당 값을 사용하도록 리팩토링

2. 재료 입력
- 마찬가지로 재료 DB에 없는 데이터를 입력할 수 없었음
- 재료명을 검증하여 DB에 존재하면 그것을 사용하고, 없으면 DB에 입력한 후 해당 재료 데이터를 사용하여 게시글과 함께 저장하도록 구현

3. 요청으로 사용자 ID값을 받아 게시글과 함께 저장함